### PR TITLE
Add bash execution as login shell to cron jobs for notifier scripts

### DIFF
--- a/cronfile
+++ b/cronfile
@@ -1,2 +1,2 @@
-0 6 * * * /app/nennschluss_notifier.py >> /proc/1/fd/1 2>> /proc/1/fd/2
-0 * * * * /app/new_tournament_notifier.py >> /proc/1/fd/1 2>> /proc/1/fd/2
+0 6 * * * bash -lc /app/nennschluss_notifier.py >> /proc/1/fd/1 2>> /proc/1/fd/2
+0 * * * * bash -lc /app/new_tournament_notifier.py >> /proc/1/fd/1 2>> /proc/1/fd/2


### PR DESCRIPTION
execute python scripts with bash as a login shell